### PR TITLE
fix(STADTPULS-526): Fix weird safari glitch when hovering gh button

### DIFF
--- a/src/common/styles.css
+++ b/src/common/styles.css
@@ -968,19 +968,45 @@ footer {
   float: left;
   width: 100%;
   user-select: none;
+  position: relative;
+  z-index: 2;
 }
 
 .code-halo {
   position: absolute;
-  right: calc(12rem - 12px);
-  bottom: 0;
-  width: calc(50% - 24px - 12rem);
-  height: 150px;
-  border-top-left-radius: 50%;
-  border-top-right-radius: 50%;
+  border-top-left-radius: 100%;
+  border-top-right-radius: 100%;
   background:var(--green);
-  filter: blur(80px);
-  opacity: .6;
+  box-shadow: 0 0 200px  var(--green);
+  z-index: 1;
+  color: var(--green);
+  left: 50%;
+  bottom: 0;
+  transform: translateX(-50%);
+  width: calc(100% - 24rem);
+  height: 80px;
+}
+
+@media screen and (min-width: 741px) {
+  .code-halo {
+    left: auto;
+    right: 12rem;
+    width: calc(50% - 24px - 12rem);
+    height: 150px;
+    transform: none;
+  }
+}
+
+@media screen and (min-width: 901px) {
+  .code-halo {
+    right: 14rem;
+  }
+}
+
+@media screen and (min-width: 1024px) {
+  .code-halo {
+    right: 16rem;
+  }
 }
 
 @media screen and (max-width: 740px) {
@@ -998,15 +1024,6 @@ footer {
     margin: 4rem 12rem 0;
     top: 0;
     height: 150px;
-  }
-
-  .code-halo {
-    left: 50%;
-    bottom: 0;
-    transform: translateX(-50%);
-    width: 100%;
-    height: 150px;
-    opacity: 0.4;
   }
 }
 


### PR DESCRIPTION
This PR fixes the bug that when hovering the GitHub button in the footer, the glow behind the code block would glitch. This was due to the css `filter: blur()` and was replaced with a `box-shadow` property. Not sure why filter causes such problems, I guess because it's safari, but the problem is now fixed. 